### PR TITLE
Allow for atlas labels to contain more than 256 segmentations

### DIFF
--- a/python/compute_values_across_segmentation
+++ b/python/compute_values_across_segmentation
@@ -23,7 +23,7 @@ if __name__ == "__main__":
         parser.error("Incorrect number of arguments")
     
     inf = volumeFromFile(args[0], dtype="double")
-    atlas = volumeFromFile(args[1], dtype='ubyte')
+    atlas = volumeFromFile(args[1], dtype='ushort', labels=True)
     output = open(args[2], 'w')
     
     labels = unique(atlas.data)


### PR DESCRIPTION
Changed ubyte to ushort datatype to allow for the input labels file to have more than 256 segmentations.
