### PR TITLE
Fix perl shebangs

### DIFF
--- a/perl/concatenate_tags
+++ b/perl/concatenate_tags
@@ -1,9 +1,9 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 
-my $usage = "This program takes two files containing tag points from a 
-single volume and will create a third file where the tags 
-from file 1 and 2 are concatenated. This output file can 
+my $usage = "This program takes two files containing tag points from a
+single volume and will create a third file where the tags
+from file 1 and 2 are concatenated. This output file can
 be used with tagtoxfm or tagtoxfm_bspline to create a transformation.
 
 $0 tags1.tag tags2.tag output_concatenated.tag\n\n";
@@ -48,7 +48,7 @@ exit;
 
 sub get_start_tags {
 	my $tagfile = shift;
-	
+
 	open(TAGFILE, "< $tagfile");
 	my @lines = <TAGFILE>;
 	for(my $i = 0; $i <= $#lines; $i++) {

--- a/perl/lin_from_nlin
+++ b/perl/lin_from_nlin
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # computes the best linear fit from a non-linear transform.
 
@@ -20,7 +20,7 @@ my $mask = undef;
 
 # handle arguments
 my @left_over_args;
-my @arg_table = 
+my @arg_table =
     ( @DefaultArgs,
       ["Linear transform type", "section"],
       ["-lsq12", "const", "-lsq12", \$transformType,

--- a/perl/make_xfm_for_grid.pl
+++ b/perl/make_xfm_for_grid.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # generates an xfm file for a provided grid file
 
@@ -18,7 +18,7 @@ $0 [options] deformation_grid.mnc output_xfm_for_grid.xfm\n";
 
 # handle arguments
 my @left_over_args;
-my @arg_table = 
+my @arg_table =
     ( @DefaultArgs,
     );
 


### PR DESCRIPTION
Fix the shebangs in some perl scripts. This is important for the new ComputeCanada modules which package a non-system perl.